### PR TITLE
Upgrade to Elm 0.18

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -10,8 +10,8 @@
         "GraphQL"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
-        "evancz/elm-http": "3.0.1 <= v < 4.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/http": "1.0.0 <= v < 2.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/src/GraphQL.elm
+++ b/src/GraphQL.elm
@@ -1,8 +1,10 @@
-module GraphQL exposing
-    ( query
-    , mutation
-    , apply
-    , maybeEncode )
+module GraphQL
+    exposing
+        ( query
+        , mutation
+        , apply
+        , maybeEncode
+        )
 
 {-| This library provides support functions used by
     [elm-graphql](https://github.com/jahewson/elm-graphql), the GraphQL code generator for Elm.


### PR DESCRIPTION
Just ran elm-upgrade (https://www.npmjs.com/package/elm-upgrade) on a project where I'm using elm-graphql-module, and got an message that elm-graphql-module is not upgraded to elm 0.18. So here is the result of running elm-upgrade on elm-graphql-module 😄 